### PR TITLE
Enable docs.google.com embeds

### DIFF
--- a/dev-docs/docs/introduction/render-deployment.mdx
+++ b/dev-docs/docs/introduction/render-deployment.mdx
@@ -1,0 +1,39 @@
+---
+title: Deploy to Render
+---
+
+This guide outlines a simple way to host Excalidraw using [Render](https://render.com/).
+
+## 1. Fork the repository
+
+Create a fork of [excalidraw](https://github.com/excalidraw/excalidraw) on GitHub so you can deploy your own instance.
+
+## 2. Build a Docker image
+
+Render can deploy services from a Dockerfile. The project already contains a `Dockerfile` that builds the app and serves it using Nginx.
+
+```
+# from project root
+docker build -t excalidraw/excalidraw .
+```
+
+Push this image to a registry that Render can access (such as Docker Hub or GitHub Container Registry).
+
+## 3. Create a web service on Render
+
+1. Log in to your Render account.
+2. Create a **new Web Service** and choose **Docker** as the environment.
+3. Provide the Docker image you pushed in the previous step.
+4. Set the **Start Command** to:
+
+```
+nginx -g 'daemon off;'
+```
+
+5. Expose port **80**. Render will automatically serve the application at the generated URL.
+
+## 4. Visit your deployment
+
+Once the service finishes deploying, open the Render URL in your browser to use your self‑hosted Excalidraw instance.
+
+For updates, rebuild your Docker image and trigger a new deploy on Render.

--- a/dev-docs/sidebars.js
+++ b/dev-docs/sidebars.js
@@ -21,7 +21,11 @@ const sidebars = {
         type: "doc",
         id: "introduction/get-started",
       },
-      items: ["introduction/development", "introduction/contributing"],
+      items: [
+        "introduction/development",
+        "introduction/contributing",
+        "introduction/render-deployment",
+      ],
     },
     {
       type: "category",

--- a/packages/element/src/embeddable.ts
+++ b/packages/element/src/embeddable.ts
@@ -72,6 +72,7 @@ const ALLOWED_DOMAINS = new Set([
   "giphy.com",
   "reddit.com",
   "forms.microsoft.com",
+  "docs.google.com",
 ]);
 
 const ALLOW_SAME_ORIGIN = new Set([
@@ -86,6 +87,7 @@ const ALLOW_SAME_ORIGIN = new Set([
   "stackblitz.com",
   "reddit.com",
   "forms.microsoft.com",
+  "docs.google.com",
 ]);
 
 export const createSrcDoc = (body: string) => {

--- a/packages/excalidraw/CHANGELOG.md
+++ b/packages/excalidraw/CHANGELOG.md
@@ -849,6 +849,8 @@ define: {
 
 - Support giphy.com embed domain [#7192](https://github.com/excalidraw/excalidraw/pull/7192)
 
+- Support docs.google.com embed domain [#0000](https://github.com/excalidraw/excalidraw/pull/0000)
+
 - Renderer tweaks [#6698](https://github.com/excalidraw/excalidraw/pull/6698)
 
 - Closing of "Save to.." Dialog on Save To Disk [#7168](https://github.com/excalidraw/excalidraw/pull/7168)


### PR DESCRIPTION
## Summary
- add `docs.google.com` to allowed embed domains
- document how to deploy Excalidraw on Render

## Testing
- `yarn test:update`
- `yarn test:typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6865ebecd978832498bddce62e795d6a